### PR TITLE
specify initial pose in the yaml config

### DIFF
--- a/fovis_ros/config/fovis/anymal.yaml
+++ b/fovis_ros/config/fovis/anymal.yaml
@@ -14,7 +14,11 @@ output_body_pose_topic : "/fovis/pose_in_odom"
 output_tf_frame : "base_fovis"
 
 # 0 cfg file. 1 IMU r & p. 2 using a pose topic
-pose_initialization_mode : 2
+initial_pose_mode : 2
+# if above is 0, then use this position and rpy (degrees) in init
+initial_position : [0,0,0]
+initial_rpy : [0,0,0]
+
 extrapolate_when_vo_fails : false
 
 # 0: older. 1: well used on MultiSense. 2: used on MultiSense, higher fps and real time

--- a/fovis_ros/config/fovis/rooster.yaml
+++ b/fovis_ros/config/fovis/rooster.yaml
@@ -23,7 +23,11 @@ orientation_fusion_mode : 0
 # 0 config file
 # 1 IMU roll and pitch
 # 2 using a pose topic
-pose_initialization_mode : 0
+initial_pose_mode : 0
+# if above is 0, then use this position and rpy (degrees) in init
+initial_position : [0,0,0]
+initial_rpy : [0,0,0]
+
 extrapolate_when_vo_fails : false
 
 # 0: older

--- a/fovis_ros/include/fovision_apps/fovision_fusion_core.hpp
+++ b/fovis_ros/include/fovision_apps/fovision_fusion_core.hpp
@@ -14,7 +14,8 @@ struct FusionCoreConfig
   int orientation_fusion_mode = 0;
 
   // how should we set the initial pose? 0 using the config file, 1 using imu, 2 using a pose source
-  int pose_initialization_mode = 0;
+  int initial_pose_mode = 0;
+  Eigen::Isometry3d initial_pose = Eigen::Isometry3d::Identity();
 
   bool publish_feature_analysis = false;
 

--- a/fovis_ros/src/fovision_apps/fovision_fusion_core.cpp
+++ b/fovis_ros/src/fovision_apps/fovision_fusion_core.cpp
@@ -63,10 +63,10 @@ FusionCore::FusionCore(const FusionCoreConfig& fcfg) :
 
   pose_initialized_ = false;
   // if not using imu or pose, initialise with robot model
-  if (fcfg_.pose_initialization_mode == 0){
+  if (fcfg_.initial_pose_mode == 0){
     std::cout << "Pose initialized using cfg\n";
-    Eigen::Isometry3d body_to_local_initial = Eigen::Isometry3d::Identity();
-    //get_trans_with_utime( botframes_ ,  "body", "local", 0, body_to_local_initial);
+    Eigen::Isometry3d body_to_local_initial = fcfg_.initial_pose;
+    //body_to_local_initial.setIdentity();
     estimator_->setBodyPose(body_to_local_initial);  
     pose_initialized_ = true;
   }

--- a/fovis_ros/src/fovision_apps/fovision_fusion_ros.cpp
+++ b/fovis_ros/src/fovision_apps/fovision_fusion_ros.cpp
@@ -20,8 +20,17 @@ int main(int argc, char **argv){
   nh.getParam("orientation_fusion_mode", fcfg.orientation_fusion_mode);
   cout << fcfg.orientation_fusion_mode << " is orientation_fusion_mode\n";
 
-  nh.getParam("pose_initialization_mode", fcfg.pose_initialization_mode);
-  cout << fcfg.pose_initialization_mode << " is pose_initialization_mode\n";
+  nh.getParam("initial_pose_mode", fcfg.initial_pose_mode);
+  cout << fcfg.initial_pose_mode << " is initial_pose_mode\n";
+
+  std::vector<double> initial_position, initial_rpy;
+  nh.getParam("initial_position", initial_position);
+  nh.getParam("initial_rpy", initial_rpy);
+  Eigen::Isometry3d initial_pose = Eigen::Isometry3d::Identity();
+  initial_pose.translation() << initial_position[0], initial_position[1], initial_position[2];
+  Eigen::Quaterniond initial_quat = euler_to_quat( initial_rpy[0]*M_PI/180.0, initial_rpy[1]*M_PI/180.0, initial_rpy[2]*M_PI/180.0);
+  initial_pose.rotate(initial_quat);
+  fcfg.initial_pose = initial_pose;
 
   nh.getParam("config_filename", fcfg.config_filename);
   cout << fcfg.config_filename << " is config_filename [full path]\n";

--- a/fovis_ros/src/fovision_apps/stereo_odom_ros.cpp
+++ b/fovis_ros/src/fovision_apps/stereo_odom_ros.cpp
@@ -340,7 +340,7 @@ void StereoOdom::imuSensorCallback(const sensor_msgs::ImuConstPtr& msg)
   }
 
 
-  if ( (!vo_core_->isPoseInitialized()) &&  (fcfg_.pose_initialization_mode == 1) ){
+  if ( (!vo_core_->isPoseInitialized()) &&  (fcfg_.initial_pose_mode == 1) ){
     std::cout << "IMU callback: initializing pose using IMU (roll and pitch)\n";
     Eigen::Isometry3d init_pose;
     init_pose.setIdentity();


### PR DESCRIPTION
this PR specifies a starting point for fovis from the yaml config file.
(previously it was hard coded to be the origin)

this allows us to start fovis with a certain pitch and roll, which can be useful e.g. if the sensor was tilted at the start of the experiment.
... in turn AICP will have that initial pitch and roll when running with rooster.

@mramezani64 and @mcamurri  is it ok to merge this?